### PR TITLE
delete the fake global `module` object in `_export_wrap`

### DIFF
--- a/src/playwright_ui5_select/__init__.py
+++ b/src/playwright_ui5_select/__init__.py
@@ -31,8 +31,12 @@ def _export_wrap(raw: str) -> str:
         if (typeof module === 'undefined') {{
             window.module = {{exports: {{}}}};
         }}
-        {raw};
-        return module.exports.default
+        try {{
+            {raw};
+            return module.exports.default
+        }} finally {{
+            delete module
+        }}
     }})()"""
 
 

--- a/src/playwright_ui5_select/__init__.py
+++ b/src/playwright_ui5_select/__init__.py
@@ -28,14 +28,17 @@ def _export_wrap(raw: str) -> str:
     See https://github.com/microsoft/playwright/issues/36448 for details.
     """
     return f"""(() => {{
-        if (typeof module === 'undefined') {{
+        const useFakeModule = typeof module === 'undefined'
+        if (useFakeModule) {{
             window.module = {{exports: {{}}}};
         }}
         try {{
             {raw};
             return module.exports.default
         }} finally {{
-            delete module
+            if (useFakeModule) {{
+                delete module
+            }}
         }}
     }})()"""
 


### PR DESCRIPTION
this was causing very strange issues on one of the sites at work. it was intermittently hanging after navigating to a page if the next playwright action uses a custom selector engine.

i'm not sure exactly what was going on, but i don't think it's safe to mess with the globals without cleaning it up afterwards anyway